### PR TITLE
Added text label to save slot menu

### DIFF
--- a/SaveBackup/BackupMenuData.cs
+++ b/SaveBackup/BackupMenuData.cs
@@ -20,6 +20,9 @@ namespace SaveBackup
 
         public static GameObject backupListUI;
 
+        public static GameObject saveSlotUILabel;
+
+        public static TextMesh saveSlotUILabelText;
         public static void Setup()
         {
             SetupButton();
@@ -88,6 +91,17 @@ namespace SaveBackup
                 var saveSlotUI = startMenu.GetPrivateField<GameObject>("saveSlotUI");
                 if (saveSlotUI)
                 {
+                    // Create UI label
+                    var saveSlotUIText = saveSlotUI.transform.GetChildByName("text").gameObject;
+                    if (saveSlotUIText)
+                    {
+                        saveSlotUILabel = GameObject.Instantiate(saveSlotUIText, saveSlotUIText.transform.position, saveSlotUIText.transform.rotation, saveSlotUI.transform);
+                        saveSlotUILabel.name = "label text";
+                        saveSlotUILabelText = saveSlotUILabel.GetComponent<TextMesh>();
+                        saveSlotUILabelText.fontSize = 80;
+                        saveSlotUILabelText.fontStyle = FontStyle.Bold;
+                    }
+
                     // Create backup UI
                     backupSlotUI = GameObject.Instantiate(saveSlotUI.gameObject);
                     backupSlotUI.name = "backup slot ui";
@@ -98,7 +112,10 @@ namespace SaveBackup
                     backupSlotUI.AddComponent<BackupMenu>().startMenu = startMenu;
                     backupSlotUI.SetActive(false);
 
-                    foreach(var button in backupSlotUI.GetComponentsInChildren<StartMenuButton>())
+                    // Set text for label created above
+                    backupSlotUI.transform.GetChildByName("label text").GetComponent<TextMesh>().text = "Backups\n";
+
+                    foreach (var button in backupSlotUI.GetComponentsInChildren<StartMenuButton>())
                     {
                         int slot = button.GetPrivateField<int>("saveSlot");
                         StartMenuButtonType type = button.GetPrivateField<StartMenuButtonType>("type");

--- a/SaveBackup/Patches/BackMenuPatches.cs
+++ b/SaveBackup/Patches/BackMenuPatches.cs
@@ -16,6 +16,7 @@ namespace SaveBackup.Patches
             [HarmonyPostfix]
             public static void Postfix(StartMenu __instance)
             {
+                BackupMenuData.saveSlotUILabelText.text = __instance.GetPrivateField<bool>("selectedContinue") ? "Continue\n" : "New Game\n";
                 BackupMenuData.backupMenuButton.SetActive(__instance.GetPrivateField<bool>("selectedContinue"));
             }
         }


### PR DESCRIPTION
Label says: "Continue", "New Game", or "Backups", to avoid confusion when choosing a save slot.
![image](https://github.com/AppSailwindMods/SaveBackup/assets/109632837/3a74abcf-48c9-46bb-a3be-a87c316a9032)
